### PR TITLE
Create consistent filenames when using multiple message types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target/
 .idea/
 *.iml
 .DS_Store
+.project
+.classpath
+.settings/

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -42,6 +42,7 @@
  */
 package org.smooks.cartridges.edifact;
 
+import com.ctc.wstx.util.StringUtil;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import org.apache.daffodil.japi.DataProcessor;
@@ -67,8 +68,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -99,8 +103,19 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
                 schema = new URI(version.toLowerCase() + "/EDIFACT-Interchange.dfdl.xsd");
             } else {
                 final List<String> messageTypes = (List) messageTypeParameters.stream().map(m -> m.getValue()).collect(Collectors.toList());
+                
+                StringBuilder aSB = new StringBuilder ();
+                for (String s : messageTypes)
+                  aSB.append (s);
+                final byte[] md = MessageDigest.getInstance ("MD5").digest (aSB.toString ().getBytes (StandardCharsets.UTF_8));
+                aSB = new StringBuilder (md.length * 2);
+                for (byte b : md)
+                  aSB.append (Character.forDigit ((b & 0xf0) >> 4, 16)).append (Character.forDigit (b & 0x0f, 16));
+                
+                // TODO find correct directory
+                final File generatedSchema = new File (version.toLowerCase() + "/EDIFACT-Interchange-"+aSB.toString ().toLowerCase (Locale.ROOT)+".dfdl.xsd");
+                generatedSchema.getParentFile ().mkdirs ();
 
-                final File generatedSchema = File.createTempFile("EDIFACT-Interchange", ".dfdl.xsd");
                 try (FileWriter fileWriter = new FileWriter(generatedSchema)) {
                     MUSTACHE.execute(fileWriter, new HashMap<String, Object>() {{
                         this.put("schemaLocation", schemaURIParameter.getValue());


### PR DESCRIPTION
Hi guys,
this PR is meant to solve an issue, if Smooks EDI configuration is run with multiple message types, when "cache on disk" is set to `true`.
This change ensures that the file can be found again later in a consecutive call. This effectively enables caching on disk ;-)
The choice of the directory is potentially not ideal - but I trust your instinct on finding something better :D
hth