### PR TITLE
build: reduce build log output because Travis is terminating the job …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,15 @@ before_install:
 jdk:
   - openjdk8
 
+script:
+  - mvn test -B -U
+
 deploy:
   provider: script
   script: bash deploy.sh
   on:
     branch: master
+    
+cache:
+  directories:
+    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <quiet>true</quiet>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
…since it's exceeding the maximum log length