### PR TITLE
chore: include the license header in all the generated DFDL schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           echo $GPG_SECRET_KEYS | base64 --decode | gpg --import --no-tty --batch --yes
           echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust
-          mvn deploy clean --settings .mvn/settings.xml -Dgpg.skip=false -DskipTests=true -B
+          mvn deploy --settings .mvn/settings.xml -Dgpg.skip=false -DskipTests=true -B

--- a/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Messages.dfdl.xsd.mustache
+++ b/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Messages.dfdl.xsd.mustache
@@ -1,4 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ========================LICENSE_START=================================
+  smooks-edifact-cartridge
+  %%
+  Copyright (C) 2020 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
 <xsd:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
             xmlns:ibmSchExtn="http://www.ibm.com/schema/extensions"
             xmlns:ibmEdiFmt="http://www.ibm.com/dfdl/EDI/Format"

--- a/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Segments.dfdl.xsd.mustache
+++ b/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Segments.dfdl.xsd.mustache
@@ -1,4 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ========================LICENSE_START=================================
+  smooks-edifact-cartridge
+  %%
+  Copyright (C) 2020 Smooks
+  %%
+  Licensed under the terms of the Apache License Version 2.0, or
+  the GNU Lesser General Public License version 3.0 or later.
+  
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+  
+  ======================================================================
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  ======================================================================
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  =========================LICENSE_END==================================
+  -->
+
 <xsd:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
             xmlns:ibmEdiFmt="http://www.ibm.com/dfdl/EDI/Format"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"


### PR DESCRIPTION
Refs: https://github.com/smooks/smooks-edi-cartridge/issues/51