### PR TITLE
fix: solve compilation failures following upstream breaking changes i…

### DIFF
--- a/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Interchange.dfdl.xsd.mustache
+++ b/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Interchange.dfdl.xsd.mustache
@@ -18,7 +18,6 @@
 	*********************************************************************** -->
 <xsd:schema
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-        xmlns:ibmSchExtn="http://www.ibm.com/schema/extensions"
         xmlns:ibmEdiFmt="http://www.ibm.com/dfdl/EDI/Format"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:srv="http://www.ibm.com/dfdl/edi/un/service/4.1"
@@ -35,7 +34,7 @@
         </xsd:appinfo>
     </xsd:annotation>
 
-    <xsd:element ibmSchExtn:docRoot="true" name="Interchange" dfdl:lengthKind="implicit">
+    <xsd:element name="Interchange" dfdl:lengthKind="implicit">
         <xsd:complexType>
             <xsd:sequence>
                 <xsd:element dfdl:terminator="%NL;%WSP*; %WSP*;" dfdl:initiator="UNA" dfdl:length="6" dfdl:lengthKind="explicit" name="UNA" type="srv:UNA" minOccurs="0"/>
@@ -65,7 +64,7 @@
         </xsd:complexType>
     </xsd:element>
 
-    <xsd:element ibmSchExtn:docRoot="true" name="Message">
+    <xsd:element name="Message">
         <xsd:complexType>
             <xsd:sequence>
                 <xsd:element dfdl:ref="ibmEdiFmt:EDISegmentFormat" dfdl:initiator="UNH" name="UNH" type="srv:UNH-MessageHeader"/>

--- a/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Service-Segments-4.1.dfdl.xsd
+++ b/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Service-Segments-4.1.dfdl.xsd
@@ -29,7 +29,6 @@
     *                  schemaLocation="EDIFACT-Service-Segments-4.1.xsd"/>
     *********************************************************************** -->
 <xsd:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-            xmlns:ibmSchExtn="http://www.ibm.com/schema/extensions"
             xmlns:ibmEdiFmt="http://www.ibm.com/dfdl/EDI/Format"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:fn="http://www.w3.org/2005/xpath-functions"
@@ -141,7 +140,7 @@
     </xsd:complexType>
 
 
-    <xsd:element ibmSchExtn:docRoot="true" name="AUTACK" type="srv:AUTACK">
+    <xsd:element name="AUTACK" type="srv:AUTACK">
     </xsd:element>
     <xsd:complexType name="AUTACK">
         <xsd:sequence>
@@ -223,7 +222,7 @@
         </xsd:sequence>
     </xsd:complexType>
 
-    <xsd:element ibmSchExtn:docRoot="true" name="CONTRL" type="srv:CONTRL">
+    <xsd:element name="CONTRL" type="srv:CONTRL">
     </xsd:element>
     <xsd:complexType name="CONTRL">
         <xsd:sequence>
@@ -307,7 +306,7 @@
         </xsd:sequence>
     </xsd:complexType>
 
-    <xsd:element ibmSchExtn:docRoot="true" name="KEYMAN" type="srv:KEYMAN">
+    <xsd:element name="KEYMAN" type="srv:KEYMAN">
     </xsd:element>
     <xsd:complexType name="KEYMAN">
         <xsd:sequence>

--- a/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Messages.dfdl.xsd.mustache
+++ b/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Messages.dfdl.xsd.mustache
@@ -43,7 +43,6 @@
   -->
 
 <xsd:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-            xmlns:ibmSchExtn="http://www.ibm.com/schema/extensions"
             xmlns:ibmEdiFmt="http://www.ibm.com/dfdl/EDI/Format"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:srv="http://www.ibm.com/dfdl/edi/un/service/4.1"
@@ -68,8 +67,7 @@
     </xsd:annotation>
 
     {{#messages}}
-        <xsd:element ibmSchExtn:docRoot="true" name="{{value.segments.xmlName}}" type="{{version}}:{{value.segments.xmlName}}">
-        </xsd:element>
+        <xsd:element name="{{value.segments.xmlName}}" type="{{version}}:{{value.segments.xmlName}}"/>
         <xsd:complexType name="{{value.segments.xmlName}}">
             <xsd:sequence>
                 {{#value.segments.segments}}
@@ -79,7 +77,7 @@
         </xsd:complexType>
     {{/messages}}
 
-    <xsd:element ibmSchExtn:docRoot="true" name="BadMessage">
+    <xsd:element name="BadMessage">
         <xsd:complexType>
             <xsd:sequence>
                 <xsd:element dfdl:ref="ibmEdiFmt:EDISegmentFormat" name="Segment" minOccurs="0" maxOccurs="unbounded">

--- a/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Segments.dfdl.xsd.mustache
+++ b/edg/src/main/resources/EDIFACT-Templates/EDIFACT-Segments.dfdl.xsd.mustache
@@ -58,7 +58,8 @@
     </xsd:annotation>
 
    {{#segments}}
-        <xsd:complexType name="{{value.xmlName}}">
+       <xsd:element name="{{value.xmlName}}" type="{{version}}:{{value.xmlName}}"/>
+       <xsd:complexType name="{{value.xmlName}}">
             <xsd:sequence dfdl:ref="ibmEdiFmt:EDISegmentSequenceFormat">
                 {{#value.fields}}
                     {{value.render}}

--- a/edi-cartridge/src/main/java/org/smooks/cartridges/edi/EdiDataProcessorFactory.java
+++ b/edi-cartridge/src/main/java/org/smooks/cartridges/edi/EdiDataProcessorFactory.java
@@ -89,7 +89,7 @@ public class EdiDataProcessorFactory extends DataProcessorFactory {
     }
 
     protected DataProcessor doCreateDataProcessor(final Map<String, String> variables) throws URISyntaxException {
-        final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")));
+        final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), null);
         return compileOrGet(dfdlSchema);
     }
 

--- a/edi-cartridge/src/test/resources/smooks-unparser-config.xml
+++ b/edi-cartridge/src/test/resources/smooks-unparser-config.xml
@@ -48,7 +48,9 @@
 
     <core:smooks filterSourceOn="/test-message">
         <core:action>
-            <core:inline directive="REPLACE"/>
+            <core:inline>
+                <core:replace/>
+            </core:inline>
         </core:action>
         <core:config>
             <smooks-resource-list>

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -103,7 +103,7 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
                 entrySchemaUri = materialiseEntrySchema(schemaUriParameter.getValue(), messageTypes, version);
             }
 
-            final DfdlSchema dfdlSchema = new DfdlSchema(entrySchemaUri, variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false"))) {
+            final DfdlSchema dfdlSchema = new DfdlSchema(entrySchemaUri, variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), null) {
                 @Override
                 public String getName() {
                     return schemaUriParameter.getValue() + ":" + getValidationMode() + ":" + isCacheOnDisk() + ":" + isDebugging() + ":" + variables.toString();

--- a/edifact-cartridge/src/test/resources/smooks-unparser-config.xml
+++ b/edifact-cartridge/src/test/resources/smooks-unparser-config.xml
@@ -48,7 +48,9 @@
 
     <core:smooks filterSourceOn="/Interchange">
         <core:action>
-            <core:inline directive="REPLACE"/>
+            <core:inline>
+                <core:replace/>
+            </core:inline>
         </core:action>
         <core:config>
             <smooks-resource-list>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
                 <artifactId>scala-library</artifactId>
                 <version>2.12.11</version>
             </dependency>
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>stax2-api</artifactId>
+                <version>4.2.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     


### PR DESCRIPTION
…n smooks/smooks#409 and smooks-dfdl-cartridge/smooks-dfdl-cartridge#51

remove unsupported DFDL extensions from generated schemas

allow segments to referenced as distinguished root nodes from Apache Daffodil