### PR TITLE
Fix the parser to generate java code from edifact schemas. Codes were…

### DIFF
--- a/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/parser/UnEdifactDirectoryParser.java
+++ b/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/parser/UnEdifactDirectoryParser.java
@@ -612,11 +612,7 @@ public class UnEdifactDirectoryParser implements DirectoryParser {
             Matcher codeMatcher = CODE.matcher(line);
             if (codeMatcher.matches()) {
                 codeList.getCodes().add(codeMatcher.group(2));
-                while (line != null && line.length() > 0) {
-                    line = reader.readLine();
-                }
             }
-
             line = reader.readLine();
         }
 

--- a/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/parser/UnEdifactDirectoryParser.java
+++ b/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/parser/UnEdifactDirectoryParser.java
@@ -198,7 +198,7 @@ public class UnEdifactDirectoryParser implements DirectoryParser {
      * Group1 = change indicator
      * Group2 = code
      */
-    private static final Pattern CODE = Pattern.compile("^([+*#|X]){0,2} +([A-Z0-9]+) +.+");
+    private static final Pattern CODE = Pattern.compile("^([+*#|X]){0,2} +([A-Z]+ +|[0-9]+) +.+");
     
     private HashMap<String, CodeList> codeLists;
     private HashMap<String, Field> compositeDataElements;
@@ -611,7 +611,7 @@ public class UnEdifactDirectoryParser implements DirectoryParser {
         while (line != null && !line.matches(ELEMENT_SEPARATOR)) {
             Matcher codeMatcher = CODE.matcher(line);
             if (codeMatcher.matches()) {
-                codeList.getCodes().add(codeMatcher.group(2));
+                codeList.getCodes().add(codeMatcher.group(2).trim());
             }
             line = reader.readLine();
         }

--- a/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D94ADirectoryParserTest.java
+++ b/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D94ADirectoryParserTest.java
@@ -58,6 +58,7 @@ import org.smooks.edi.edisax.model.internal.CodeList;
 import org.smooks.edi.edisax.model.internal.Edimap;
 import org.smooks.edi.edisax.model.internal.Field;
 import org.smooks.edi.edisax.model.internal.Segment;
+import org.smooks.edi.edisax.util.IllegalNameException;
 import org.smooks.support.StreamUtils;
 import org.xmlunit.builder.DiffBuilder;
 
@@ -74,12 +75,17 @@ import static org.junit.jupiter.api.Assertions.*;
 public class D94ADirectoryParserTest {
 
     private DirectoryParser d94AReader;
+    private DirectoryParser d96AReader;
 
     @BeforeEach
     public void init() throws Exception {
         InputStream inputStream = getClass().getResourceAsStream("/d94a.zip");
         ZipInputStream zipInputStream = new ZipInputStream(inputStream);
         d94AReader = new D94ADirectoryParser(zipInputStream, false, false);
+
+        inputStream = getClass().getResourceAsStream("/d96a.zip");
+        zipInputStream = new ZipInputStream(inputStream);
+        d96AReader = new D96ADirectoryParser(zipInputStream, false, false);
     }
 
     @Test
@@ -177,6 +183,63 @@ public class D94ADirectoryParserTest {
         for (final Field field : aliSegment.getFields()) {
             assertFalse(field.getDocumentation().contains("3166"));
         }
+    }
+
+    @Test
+    public void checkCorrectParsingOfCodesD96A() throws IOException, JDOMException {
+        Edimap edimap = UnEdifactDefinitionReader.parse(d96AReader);
+
+        StringWriter stringWriter = new StringWriter();
+        edimap.write(stringWriter);
+
+        edimap.getSimpleDataElements().forEach(a -> {
+            if (a.getCodeList() != null) {
+                assertTrue(a.getCodeList().getCodes().size() > 0);
+            }
+            if (a.getNodeTypeRef().equals("1153")) {
+                assertTrue(a.getCodeList().getCodes().contains("AAA"));
+                assertTrue(a.getCodeList().getCodes().contains("AEK"));
+                assertTrue(a.getCodeList().getCodes().contains("AEJ"));
+                assertTrue(a.getCodeList().getCodes().contains("VN"));
+                assertTrue(a.getCodeList().getCodes().contains("ON"));
+                assertTrue(a.getCodeList().getCodes().contains("BT"));
+                assertTrue(a.getCodeList().getCodes().contains("VA"));
+            }
+            if (a.getNodeTypeRef().equals("3139")) {
+                assertTrue(a.getCodeList().getCodes().contains("IC"));
+            }
+            if (a.getNodeTypeRef().equals("3155")) {
+                assertTrue(a.getCodeList().getCodes().contains("TE"));
+            }
+            if (a.getNodeTypeRef().equals("6311")) {
+                assertTrue(a.getCodeList().getCodes().contains("AAY"));
+            }
+            if (a.getNodeTypeRef().equals("6313")) {
+                assertTrue(a.getCodeList().getCodes().contains("HM"));
+                assertTrue(a.getCodeList().getCodes().contains("LM"));
+                assertTrue(a.getCodeList().getCodes().contains("WM"));
+                assertTrue(a.getCodeList().getCodes().contains("GW"));
+                assertTrue(a.getCodeList().getCodes().contains("LM"));
+            }
+            if (a.getNodeTypeRef().equals("7143")) {
+                assertTrue(a.getCodeList().getCodes().contains("BP"));
+                assertTrue(a.getCodeList().getCodes().contains("VP"));
+            }
+            if (a.getNodeTypeRef().equals("7077")) {
+                assertTrue(a.getCodeList().getCodes().contains("F"));
+            }
+            if (a.getNodeTypeRef().equals("3035")) {
+                assertTrue(a.getCodeList().getCodes().contains("BY"));
+                assertTrue(a.getCodeList().getCodes().contains("SU"));
+            }
+            if (a.getNodeTypeRef().equals("5125")) {
+                assertTrue(a.getCodeList().getCodes().contains("INF"));
+            }
+            if (a.getNodeTypeRef().equals("5387")) {
+                assertTrue(a.getCodeList().getCodes().contains("NTP"));
+            }
+        });
+
     }
 
     private void testSegment(final String segmentCode, Document doc, boolean useShortName) throws IOException, JDOMException {

--- a/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D94ADirectoryParserTest.java
+++ b/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D94ADirectoryParserTest.java
@@ -75,17 +75,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class D94ADirectoryParserTest {
 
     private DirectoryParser d94AReader;
-    private DirectoryParser d96AReader;
 
     @BeforeEach
     public void init() throws Exception {
         InputStream inputStream = getClass().getResourceAsStream("/d94a.zip");
         ZipInputStream zipInputStream = new ZipInputStream(inputStream);
         d94AReader = new D94ADirectoryParser(zipInputStream, false, false);
-
-        inputStream = getClass().getResourceAsStream("/d96a.zip");
-        zipInputStream = new ZipInputStream(inputStream);
-        d96AReader = new D96ADirectoryParser(zipInputStream, false, false);
     }
 
     @Test
@@ -183,63 +178,6 @@ public class D94ADirectoryParserTest {
         for (final Field field : aliSegment.getFields()) {
             assertFalse(field.getDocumentation().contains("3166"));
         }
-    }
-
-    @Test
-    public void checkCorrectParsingOfCodesD96A() throws IOException, JDOMException {
-        Edimap edimap = UnEdifactDefinitionReader.parse(d96AReader);
-
-        StringWriter stringWriter = new StringWriter();
-        edimap.write(stringWriter);
-
-        edimap.getSimpleDataElements().forEach(a -> {
-            if (a.getCodeList() != null) {
-                assertTrue(a.getCodeList().getCodes().size() > 0);
-            }
-            if (a.getNodeTypeRef().equals("1153")) {
-                assertTrue(a.getCodeList().getCodes().contains("AAA"));
-                assertTrue(a.getCodeList().getCodes().contains("AEK"));
-                assertTrue(a.getCodeList().getCodes().contains("AEJ"));
-                assertTrue(a.getCodeList().getCodes().contains("VN"));
-                assertTrue(a.getCodeList().getCodes().contains("ON"));
-                assertTrue(a.getCodeList().getCodes().contains("BT"));
-                assertTrue(a.getCodeList().getCodes().contains("VA"));
-            }
-            if (a.getNodeTypeRef().equals("3139")) {
-                assertTrue(a.getCodeList().getCodes().contains("IC"));
-            }
-            if (a.getNodeTypeRef().equals("3155")) {
-                assertTrue(a.getCodeList().getCodes().contains("TE"));
-            }
-            if (a.getNodeTypeRef().equals("6311")) {
-                assertTrue(a.getCodeList().getCodes().contains("AAY"));
-            }
-            if (a.getNodeTypeRef().equals("6313")) {
-                assertTrue(a.getCodeList().getCodes().contains("HM"));
-                assertTrue(a.getCodeList().getCodes().contains("LM"));
-                assertTrue(a.getCodeList().getCodes().contains("WM"));
-                assertTrue(a.getCodeList().getCodes().contains("GW"));
-                assertTrue(a.getCodeList().getCodes().contains("LM"));
-            }
-            if (a.getNodeTypeRef().equals("7143")) {
-                assertTrue(a.getCodeList().getCodes().contains("BP"));
-                assertTrue(a.getCodeList().getCodes().contains("VP"));
-            }
-            if (a.getNodeTypeRef().equals("7077")) {
-                assertTrue(a.getCodeList().getCodes().contains("F"));
-            }
-            if (a.getNodeTypeRef().equals("3035")) {
-                assertTrue(a.getCodeList().getCodes().contains("BY"));
-                assertTrue(a.getCodeList().getCodes().contains("SU"));
-            }
-            if (a.getNodeTypeRef().equals("5125")) {
-                assertTrue(a.getCodeList().getCodes().contains("INF"));
-            }
-            if (a.getNodeTypeRef().equals("5387")) {
-                assertTrue(a.getCodeList().getCodes().contains("NTP"));
-            }
-        });
-
     }
 
     private void testSegment(final String segmentCode, Document doc, boolean useShortName) throws IOException, JDOMException {

--- a/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D96ADirectoryParserTest.java
+++ b/ect/src/test/java/org/smooks/edi/ect/formats/unedifact/parser/D96ADirectoryParserTest.java
@@ -42,6 +42,7 @@
  */
 package org.smooks.edi.ect.formats.unedifact.parser;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.smooks.edi.ect.DirectoryParser;
@@ -52,13 +53,22 @@ import org.smooks.edi.edisax.model.internal.Field;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class D96ADirectoryParserTest {
+    private DirectoryParser d96AReader;
+
+    @BeforeEach
+    public void init() throws Exception {
+        InputStream inputStream = getClass().getResourceAsStream("/d96a.zip");
+        ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+        d96AReader = new D96ADirectoryParser(zipInputStream, false, false);
+    }
     @Test
     @DisplayName("should extract legacy D96A code list values correctly")
     public void checkThatD96ACodeListsAreReadCorrectlyForLegacyD96A() throws Exception {
@@ -80,6 +90,62 @@ public class D96ADirectoryParserTest {
 
         final Field component = getComplexElement(d96AReader, "C770");
         assertEquals("9424", component.getComponents().get(0).getNodeTypeRef());
+    }
+
+    @Test
+    public void checkCorrectParsingOfCodesD96A() throws IOException{
+        Edimap edimap = UnEdifactDefinitionReader.parse(d96AReader);
+
+        StringWriter stringWriter = new StringWriter();
+        edimap.write(stringWriter);
+
+        edimap.getSimpleDataElements().forEach(a -> {
+            if (a.getCodeList() != null) {
+                assertTrue(a.getCodeList().getCodes().size() > 0);
+            }
+            if (a.getNodeTypeRef().equals("1153")) {
+                assertTrue(a.getCodeList().getCodes().contains("AAA"));
+                assertTrue(a.getCodeList().getCodes().contains("AEK"));
+                assertTrue(a.getCodeList().getCodes().contains("AEJ"));
+                assertTrue(a.getCodeList().getCodes().contains("VN"));
+                assertTrue(a.getCodeList().getCodes().contains("ON"));
+                assertTrue(a.getCodeList().getCodes().contains("BT"));
+                assertTrue(a.getCodeList().getCodes().contains("VA"));
+            }
+            if (a.getNodeTypeRef().equals("3139")) {
+                assertTrue(a.getCodeList().getCodes().contains("IC"));
+            }
+            if (a.getNodeTypeRef().equals("3155")) {
+                assertTrue(a.getCodeList().getCodes().contains("TE"));
+            }
+            if (a.getNodeTypeRef().equals("6311")) {
+                assertTrue(a.getCodeList().getCodes().contains("AAY"));
+            }
+            if (a.getNodeTypeRef().equals("6313")) {
+                assertTrue(a.getCodeList().getCodes().contains("HM"));
+                assertTrue(a.getCodeList().getCodes().contains("LM"));
+                assertTrue(a.getCodeList().getCodes().contains("WM"));
+                assertTrue(a.getCodeList().getCodes().contains("GW"));
+                assertTrue(a.getCodeList().getCodes().contains("LM"));
+            }
+            if (a.getNodeTypeRef().equals("7143")) {
+                assertTrue(a.getCodeList().getCodes().contains("BP"));
+                assertTrue(a.getCodeList().getCodes().contains("VP"));
+            }
+            if (a.getNodeTypeRef().equals("7077")) {
+                assertTrue(a.getCodeList().getCodes().contains("F"));
+            }
+            if (a.getNodeTypeRef().equals("3035")) {
+                assertTrue(a.getCodeList().getCodes().contains("BY"));
+                assertTrue(a.getCodeList().getCodes().contains("SU"));
+            }
+            if (a.getNodeTypeRef().equals("5125")) {
+                assertTrue(a.getCodeList().getCodes().contains("INF"));
+            }
+            if (a.getNodeTypeRef().equals("5387")) {
+                assertTrue(a.getCodeList().getCodes().contains("NTP"));
+            }
+        });
     }
 
     private Field getComplexElement(final DirectoryParser reader, final String componentName) throws IOException {


### PR DESCRIPTION
… not correctly added to the data elements

This is a fix for the bug that was reported [here](https://github.com/smooks/smooks-edi-cartridge/issues/125), on the second comment _"You've uncovered a bug in the schema generation code. We'll address it in RC1."_