### PR TITLE
build: resolve dependency conflict errors

### DIFF
--- a/edg/pom.xml
+++ b/edg/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -119,7 +119,7 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
     protected URI materialiseEntrySchema(final String schemaUri, final List<String> messageTypes, final String version) throws IOException {
         final File generatedEntrySchemaDir = Files.createTempDirectory(null).toFile();
         generatedEntrySchemaDir.deleteOnExit();
-        final File generatedEntrySchema = new File(generatedEntrySchemaDir.toString() + "/EDIFACT-Interchange-" + UUID.nameUUIDFromBytes(String.join(":", messageTypes).getBytes()) + "-.dfdl.xsd");
+        final File generatedEntrySchema = new File(generatedEntrySchemaDir + "/EDIFACT-Interchange-" + UUID.nameUUIDFromBytes(String.join(":", messageTypes).getBytes()) + ".dfdl.xsd");
         try (Writer fileWriter = new OutputStreamWriter(new FileOutputStream(generatedEntrySchema), StandardCharsets.UTF_8)) {
             MUSTACHE.execute(fileWriter, new HashMap<String, Object>() {{
                 this.put("schemaLocation", schemaUri);

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.smooks.cartridges</groupId>
             <artifactId>smooks-dfdl-cartridge</artifactId>
-            <version>1.0.0-RC1</version>
+            <version>1.0.0-RC2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
reference latest smooks-dfdl-cartridge snapshot

remove un-necessary dash from generated temporary file name