### PR TITLE
fix: solve compilation & runtime errors following changes in https://…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,12 +17,12 @@ In the following pass-through configuration, Smooks parses an EDI document and t
                       xmlns:edi="https://www.smooks.org/xsd/smooks/edi-2.0.xsd">    
 
     <!-- Configure the reader to parse the EDI stream into a stream of SAX events. -->  
-    <edi:parser schemaURI="/edi-to-xml-mapping.dfdl.xsd" // <1>
+    <edi:parser schemaUri="/edi-to-xml-mapping.dfdl.xsd" // <1>
                 segmentTerminator="%NL;" // <2>
                 compositeDataElementSeparator="^"/> // <3>
 
     <!-- Configure the writer to serialise the XML stream into EDI. -->  
-    <edi:unparser schemaURI="/edi-to-xml-mapping.dfdl.xsd" // <1>
+    <edi:unparser schemaUri="/edi-to-xml-mapping.dfdl.xsd" // <1>
                   segmentTerminator="%NL;" // <2>
                   compositeDataElementSeparator="^" // <3>
                   unparseOnNode="/Order"/> // <4>
@@ -32,7 +32,7 @@ In the following pass-through configuration, Smooks parses an EDI document and t
 
 Config attributes common to the parser and unparser resources are:
 
-. _schemaURI_: the DFDL schema describing the structure of the EDI document to be parser or unparsed. 
+. _schemaUri_: the DFDL schema describing the structure of the EDI document to be parser or unparsed.
 . _segmentTerminator_: the terminator for groups of related data elements. DFDL interprets _%NL;_ as a newline. 
 . _compositeDataElementSeparator_: the delimiter for compound data elements.
 
@@ -314,14 +314,14 @@ message definition zip directories]. This allows you to easily convert a UN/EDIF
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edifact="https://www.smooks.org/xsd/smooks/edifact-2.0.xsd">
 
-    <edifact:parser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd"/>
+    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd"/>
 
-    <edifact:unparser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="/Interchange"/>
+    <edifact:unparser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="/Interchange"/>
 
 </smooks-resource-list>
 ----
 
-The _edifact:parser_ and _edifact:unparser_, analogous to the _edi:parser_ and _edi:unparser_, convert the stream according to the pre-generated DFDL schema referenced in the _schemaURI_ attribute. Given that an EDIFACT schema can be very big compared to your average EDI schema, it may take minutes for the parser to compile it. Even having the _cacheOnDisk_ attribute enabled may not be sufficient to meet your compilation time needs. For such situations, you can mitigate this problem by declaring ahead of time which message types the parser will process:
+The _edifact:parser_ and _edifact:unparser_, analogous to the _edi:parser_ and _edi:unparser_, convert the stream according to the pre-generated DFDL schema referenced in the _schemaUri_ attribute. Given that an EDIFACT schema can be very big compared to your average EDI schema, it may take minutes for the parser to compile it. Even having the _cacheOnDisk_ attribute enabled may not be sufficient to meet your compilation time needs. For such situations, you can mitigate this problem by declaring ahead of time which message types the parser will process:
 
 .smooks-config.xml
 [source,xml]
@@ -330,14 +330,14 @@ The _edifact:parser_ and _edifact:unparser_, analogous to the _edi:parser_ and _
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edifact="https://www.smooks.org/xsd/smooks/edifact-2.0.xsd">
 
-    <edifact:parser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd">
+    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd">
         <edifact:messageTypes>
             <edifact:messageType>ORDERS</edifact:messageType>
             <edifact:messageType>INVOIC</edifact:messageType>
         </edifact:messageTypes>
     </edifact:parser>
 
-    <edifact:unparser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="/Interchange">
+    <edifact:unparser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="/Interchange">
        <edifact:messageTypes>
             <edifact:messageType>ORDERS</edifact:messageType>
             <edifact:messageType>INVOIC</edifact:messageType>
@@ -376,7 +376,7 @@ As an example, to add the D93A DFDL schema pack to your application classpath, a
 </dependency>
 ----
 
-Once you add an EDIFACT schema pack set to the application's classpath, you configure Smooks to use the schemas by referencing the root schema in _schemaURI_ attribute of the _edifact:parser_ or _edifact:unparser_ configuration (_<version>/EDIFACT-Messages.dfdl.xsd_):
+Once you add an EDIFACT schema pack set to the application's classpath, you configure Smooks to use the schemas by referencing the root schema in _schemaUri_ attribute of the _edifact:parser_ or _edifact:unparser_ configuration (_<version>/EDIFACT-Messages.dfdl.xsd_):
 
 .smooks-config.xml
 [source,xml]
@@ -385,7 +385,7 @@ Once you add an EDIFACT schema pack set to the application's classpath, you conf
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edifact="https://www.smooks.org/xsd/smooks/edifact-1.0.xsd">
 
-    <edifact:parser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd">
+    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd">
         <edifact:messages>
             <edifact:message>ORDERS</edifact:message>
             <edifact:message>INVOIC</edifact:message>

--- a/edi-cartridge/src/main/java/org/smooks/cartridges/edi/EdiDataProcessorFactory.java
+++ b/edi-cartridge/src/main/java/org/smooks/cartridges/edi/EdiDataProcessorFactory.java
@@ -89,7 +89,12 @@ public class EdiDataProcessorFactory extends DataProcessorFactory {
     }
 
     protected DataProcessor doCreateDataProcessor(final Map<String, String> variables) throws URISyntaxException {
-        final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), null);
+        final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")),
+                Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")),
+                Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")),
+                resourceConfig.getParameterValue("distinguishedRootNode", String.class),
+                resourceConfig.getParameterValue("schematronUrl", String.class),
+                Boolean.parseBoolean(resourceConfig.getParameterValue("schematronValidation", String.class)));
         return compileOrGet(dfdlSchema);
     }
 

--- a/edi-cartridge/src/main/resources/META-INF/xsd/smooks/edi-2.0.xsd-smooks.xml
+++ b/edi-cartridge/src/main/resources/META-INF/xsd/smooks/edi-2.0.xsd-smooks.xml
@@ -87,7 +87,7 @@
 
     <resource-config selector="edi:parser,edi:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">schemaURI</param>
+        <param name="attribute">schemaUri</param>
     </resource-config>
     <resource-config selector="edi:parser,edi:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>

--- a/edi-cartridge/src/test/resources/smooks-parser-config.xml
+++ b/edi-cartridge/src/test/resources/smooks-parser-config.xml
@@ -45,7 +45,7 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edi="https://www.smooks.org/xsd/smooks/edi-2.0.xsd">
 
-    <edi:parser schemaURI="/edi-to-xml-mapping.dfdl.xsd" dataElementSeparator="*" segmentTerminator="%NL;"
+    <edi:parser schemaUri="/edi-to-xml-mapping.dfdl.xsd" dataElementSeparator="*" segmentTerminator="%NL;"
                 compositeDataElementSeparator="^"/>
 
 </smooks-resource-list>

--- a/edi-cartridge/src/test/resources/smooks-unparser-config.xml
+++ b/edi-cartridge/src/test/resources/smooks-unparser-config.xml
@@ -54,7 +54,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <edi:unparser schemaURI="/edi-to-xml-mapping.dfdl.xsd" unparseOnNode="*" dataElementSeparator="*"
+                <edi:unparser schemaUri="/edi-to-xml-mapping.dfdl.xsd" unparseOnNode="*" dataElementSeparator="*"
                               segmentTerminator="%NL;" compositeDataElementSeparator="^"/>
             </smooks-resource-list>
         </core:config>

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -91,7 +91,7 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
     @Override
     public DataProcessor doCreateDataProcessor(final Map<String, String> variables) {
         try {
-            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaURI", String.class);
+            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaUri", String.class);
             final String version = readVersion(schemaUriParameter);
             final URI entrySchemaUri;
 
@@ -103,7 +103,11 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
                 entrySchemaUri = materialiseEntrySchema(schemaUriParameter.getValue(), messageTypes, version);
             }
 
-            final DfdlSchema dfdlSchema = new DfdlSchema(entrySchemaUri, variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), null) {
+            final DfdlSchema dfdlSchema = new DfdlSchema(entrySchemaUri, variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")),
+                                                         Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")),
+                                                         Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), resourceConfig.getParameterValue("distinguishedRootNode", String.class),
+                                                         resourceConfig.getParameterValue("schematronUrl", String.class),
+                                                         Boolean.parseBoolean(resourceConfig.getParameterValue("schematronValidation", String.class))) {
                 @Override
                 public String getName() {
                     return schemaUriParameter.getValue() + ":" + getValidationMode() + ":" + isCacheOnDisk() + ":" + isDebugging() + ":" + variables.toString();

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -91,7 +91,7 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
     @Override
     public DataProcessor doCreateDataProcessor(final Map<String, String> variables) {
         try {
-            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaUri", String.class);
+            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaURI", String.class);
             final String version = readVersion(schemaUriParameter);
             final URI entrySchemaUri;
 

--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -91,7 +91,7 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
     @Override
     public DataProcessor doCreateDataProcessor(final Map<String, String> variables) {
         try {
-            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaURI", String.class);
+            final Parameter<String> schemaUriParameter = resourceConfig.getParameter("schemaUri", String.class);
             final String version = readVersion(schemaUriParameter);
             final URI entrySchemaUri;
 
@@ -135,9 +135,9 @@ public class EdifactDataProcessorFactory extends EdiDataProcessorFactory {
         return generatedEntrySchema.toURI();
     }
 
-    protected String readVersion(final Parameter<String> schemaURIParameter) throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
+    protected String readVersion(final Parameter<String> schemaUriParameter) throws XPathExpressionException, ParserConfigurationException, IOException, SAXException {
         final DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-        final Document document = documentBuilder.parse(Misc.getRequiredResource(schemaURIParameter.getValue()).toString());
+        final Document document = documentBuilder.parse(Misc.getRequiredResource(schemaUriParameter.getValue()).toString());
 
         final XPathFactory factory = XPathFactory.newInstance();
         final XPath xpath = factory.newXPath();

--- a/edifact-cartridge/src/main/resources/META-INF/xsd/smooks/edifact-2.0.xsd-smooks.xml
+++ b/edifact-cartridge/src/main/resources/META-INF/xsd/smooks/edifact-2.0.xsd-smooks.xml
@@ -87,7 +87,7 @@
 
     <resource-config selector="edifact:parser,edifact:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">schemaURI</param>
+        <param name="attribute">schemaUri</param>
     </resource-config>
     <resource-config selector="edifact:parser,edifact:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>

--- a/edifact-cartridge/src/test/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactoryTestCase.java
+++ b/edifact-cartridge/src/test/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactoryTestCase.java
@@ -82,7 +82,7 @@ public class EdifactDataProcessorFactoryTestCase {
         EdifactDataProcessorFactory edifactDataProcessorFactory = new EdifactDataProcessorFactory();
         edifactDataProcessorFactory.setResourceConfig(new DefaultResourceConfig());
         edifactDataProcessorFactory.setApplicationContext(new DefaultApplicationContextBuilder().build());
-        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaURI", "/d03b/EDIFACT-Messages.dfdl.xsd");
+        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaUri", "/d03b/EDIFACT-Messages.dfdl.xsd");
         edifactDataProcessorFactory.getResourceConfig().setParameter("messageType", "ORDERS");
 
         String originalFileEncoding = System.getProperty("file.encoding");
@@ -105,7 +105,7 @@ public class EdifactDataProcessorFactoryTestCase {
         edifactDataProcessorFactory.setResourceConfig(new DefaultResourceConfig());
         edifactDataProcessorFactory.setApplicationContext(new DefaultApplicationContextBuilder().build());
         edifactDataProcessorFactory.getResourceConfig().setParameter("cacheOnDisk", "true");
-        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaURI", "/d03b/EDIFACT-Messages.dfdl.xsd");
+        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaUri", "/d03b/EDIFACT-Messages.dfdl.xsd");
         edifactDataProcessorFactory.getResourceConfig().setParameter("messageType", "ORDERS");
         
         assertFalse(new File(DfdlSchema.WORKING_DIRECTORY).exists());
@@ -116,7 +116,7 @@ public class EdifactDataProcessorFactoryTestCase {
         cachedEdifactDataProcessorFactory.setResourceConfig(new DefaultResourceConfig());
         cachedEdifactDataProcessorFactory.setApplicationContext(new DefaultApplicationContextBuilder().build());
         cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("cacheOnDisk", "true");
-        cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("schemaURI", "/d03b/EDIFACT-Messages.dfdl.xsd");
+        cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("schemaUri", "/d03b/EDIFACT-Messages.dfdl.xsd");
         cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("messageType", "ORDERS");
 
         assertEquals(1, new File(DfdlSchema.WORKING_DIRECTORY).listFiles().length);
@@ -130,7 +130,7 @@ public class EdifactDataProcessorFactoryTestCase {
         edifactDataProcessorFactory.setResourceConfig(new DefaultResourceConfig());
         edifactDataProcessorFactory.setApplicationContext(new DefaultApplicationContextBuilder().build());
         edifactDataProcessorFactory.getResourceConfig().setParameter("cacheOnDisk", "true");
-        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaURI", "/d03b/EDIFACT-Messages.dfdl.xsd");
+        edifactDataProcessorFactory.getResourceConfig().setParameter("schemaUri", "/d03b/EDIFACT-Messages.dfdl.xsd");
         edifactDataProcessorFactory.getResourceConfig().setParameter("messageType", "ORDERS");
 
         assertFalse(new File(DfdlSchema.WORKING_DIRECTORY).exists());
@@ -141,7 +141,7 @@ public class EdifactDataProcessorFactoryTestCase {
         cachedEdifactDataProcessorFactory.setResourceConfig(new DefaultResourceConfig());
         cachedEdifactDataProcessorFactory.setApplicationContext(new DefaultApplicationContextBuilder().build());
         cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("cacheOnDisk", "true");
-        cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("schemaURI", "/d03b/EDIFACT-Messages.dfdl.xsd");
+        cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("schemaUri", "/d03b/EDIFACT-Messages.dfdl.xsd");
         cachedEdifactDataProcessorFactory.getResourceConfig().setParameter("messageType", "INVOIC");
 
         assertEquals(1, new File(DfdlSchema.WORKING_DIRECTORY).listFiles().length);

--- a/edifact-cartridge/src/test/resources/smooks-parser-config.xml
+++ b/edifact-cartridge/src/test/resources/smooks-parser-config.xml
@@ -45,7 +45,7 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edifact="https://www.smooks.org/xsd/smooks/edifact-2.0.xsd">
 
-    <edifact:parser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd">
+    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd">
         <edifact:messageTypes>
             <edifact:messageType>ORDERS</edifact:messageType>
             <edifact:messageType>INVOIC</edifact:messageType>

--- a/edifact-cartridge/src/test/resources/smooks-unparser-config.xml
+++ b/edifact-cartridge/src/test/resources/smooks-unparser-config.xml
@@ -54,7 +54,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <edifact:unparser schemaURI="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="*">
+                <edifact:unparser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd" unparseOnNode="*">
                     <edifact:messageTypes>
                         <edifact:messageType>ORDERS</edifact:messageType>
                         <edifact:messageType>INVOIC</edifact:messageType>


### PR DESCRIPTION
…github.com/smooks/smooks-dfdl-cartridge/pull/145

BREAKING CHANGE: rename edifact:unparser and edifact:parser `schemaURI` attribute to `schemaUri`