### PR TITLE
fix: add slash to path to resolve error caused by update to Daffodil 3.6

### DIFF
--- a/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
+++ b/edifact-cartridge/src/main/java/org/smooks/cartridges/edifact/EdifactDataProcessorFactory.java
@@ -96,7 +96,7 @@ public class EdifactDataProcessorFactory extends DataProcessorFactory {
 
             final List<Parameter<?>> messageTypeParameters = resourceConfig.getParameters("messageType");
             if (messageTypeParameters == null || messageTypeParameters.isEmpty()) {
-                entrySchemaUri = new URI(version.toLowerCase() + "/EDIFACT-Interchange.dfdl.xsd");
+                entrySchemaUri = new URI("/" + version.toLowerCase() + "/EDIFACT-Interchange.dfdl.xsd");
             } else {
                 final List<String> messageTypes = (List) messageTypeParameters.stream().map(Parameter::getValue).collect(Collectors.toList());
                 entrySchemaUri = materialiseEntrySchema(schemaUriParameter.getValue(), messageTypes, version);

--- a/edifact-cartridge/src/test/java/org/smooks/cartridges/edifact/EdifactFunctionalTestCase.java
+++ b/edifact-cartridge/src/test/java/org/smooks/cartridges/edifact/EdifactFunctionalTestCase.java
@@ -44,6 +44,7 @@ package org.smooks.cartridges.edifact;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.smooks.Smooks;
@@ -73,8 +74,8 @@ public class EdifactFunctionalTestCase {
 
     @ParameterizedTest
     @CsvSource({"/data/INVOIC_D.03B_Interchange_with_UNA.txt, /data/INVOIC_D.03B_Interchange_with_UNA.xml, 0", "/data/ORDERS_D.03B_Interchange.txt, /data/ORDERS_D.03B_Interchange.xml, 0", "/data/BAD_ORDERS_D.03B_Interchange.txt, /data/BAD_ORDERS_D.03B_Interchange.xml, 1"})
-    public void testSmooksConfigGivenParser(String fileName, String expectedResult, int diagnosticCount) throws Exception {
-        smooks.addConfigurations("/smooks-parser-config.xml");
+    public void testSmooksConfigGivenParserWithMessageTypes(String fileName, String expectedResult, int diagnosticCount) throws Exception {
+        smooks.addConfigurations("/smooks-parser-messageTypes-config.xml");
         ExecutionContext executionContext = smooks.createExecutionContext();
         String result = filterAndSerialize(executionContext, getClass().getResourceAsStream(fileName), smooks);
 
@@ -85,6 +86,16 @@ public class EdifactFunctionalTestCase {
         }
 
         assertFalse(DiffBuilder.compare(getClass().getResourceAsStream(expectedResult)).ignoreWhitespace().withTest(result).build().hasDifferences());
+    }
+
+    @Test
+    public void testSmooksConfigGivenParser() throws Exception {
+        smooks.addConfigurations("/smooks-parser-config.xml");
+        ExecutionContext executionContext = smooks.createExecutionContext();
+        String result = filterAndSerialize(executionContext, getClass().getResourceAsStream("/data/INVOIC_D.03B_Interchange_with_UNA.txt"), smooks);
+        assertNull(executionContext.get(DfdlParser.DIAGNOSTICS_TYPED_KEY));
+
+        assertFalse(DiffBuilder.compare(getClass().getResourceAsStream("/data/INVOIC_D.03B_Interchange_with_UNA.xml")).ignoreWhitespace().withTest(result).build().hasDifferences());
     }
 
     @ParameterizedTest

--- a/edifact-cartridge/src/test/resources/smooks-parser-messageTypes-config.xml
+++ b/edifact-cartridge/src/test/resources/smooks-parser-messageTypes-config.xml
@@ -3,7 +3,7 @@
   ========================LICENSE_START=================================
   smooks-edifact-cartridge
   %%
-  Copyright (C) 2020 - 2023 Smooks
+  Copyright (C) 2020 Smooks
   %%
   Licensed under the terms of the Apache License Version 2.0, or
   the GNU Lesser General Public License version 3.0 or later.
@@ -45,6 +45,11 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:edifact="https://www.smooks.org/xsd/smooks/edifact-2.0.xsd">
 
-    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd" validationMode="Full"/>
+    <edifact:parser schemaUri="/d03b/EDIFACT-Messages.dfdl.xsd" validationMode="Limited">
+        <edifact:messageTypes>
+            <edifact:messageType>ORDERS</edifact:messageType>
+            <edifact:messageType>INVOIC</edifact:messageType>
+        </edifact:messageTypes>
+    </edifact:parser>
 
 </smooks-resource-list>


### PR DESCRIPTION
Refs: https://issues.apache.org/jira/browse/DAFFODIL-2828