### PR TITLE
fix: add missing message release no. enums to E0054-MessageReleaseNum…

### DIFF
--- a/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Service-Segments-4.1.dfdl.xsd
+++ b/common-schemas/src/main/resources/EDIFACT-Common/EDIFACT-Service-Segments-4.1.dfdl.xsd
@@ -1254,6 +1254,42 @@
             </xsd:enumeration>
             <xsd:enumeration value="12B">
             </xsd:enumeration>
+            <xsd:enumeration value="13A">
+            </xsd:enumeration>
+            <xsd:enumeration value="13B">
+            </xsd:enumeration>
+            <xsd:enumeration value="14A">
+            </xsd:enumeration>
+            <xsd:enumeration value="14B">
+            </xsd:enumeration>
+            <xsd:enumeration value="15A">
+            </xsd:enumeration>
+            <xsd:enumeration value="15B">
+            </xsd:enumeration>
+            <xsd:enumeration value="16A">
+            </xsd:enumeration>
+            <xsd:enumeration value="16B">
+            </xsd:enumeration>
+            <xsd:enumeration value="17A">
+            </xsd:enumeration>
+            <xsd:enumeration value="17B">
+            </xsd:enumeration>
+            <xsd:enumeration value="18A">
+            </xsd:enumeration>
+            <xsd:enumeration value="18B">
+            </xsd:enumeration>
+            <xsd:enumeration value="19A">
+            </xsd:enumeration>
+            <xsd:enumeration value="19B">
+            </xsd:enumeration>
+            <xsd:enumeration value="20A">
+            </xsd:enumeration>
+            <xsd:enumeration value="20B">
+            </xsd:enumeration>
+            <xsd:enumeration value="21A">
+            </xsd:enumeration>
+            <xsd:enumeration value="21B">
+            </xsd:enumeration>
             <xsd:enumeration value="93A">
             </xsd:enumeration>
             <xsd:enumeration value="94A">

--- a/edg/pom.xml
+++ b/edg/pom.xml
@@ -34,14 +34,15 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-jxpath</groupId>
-            <artifactId>commons-jxpath</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.daffodil</groupId>
             <artifactId>daffodil-tdml-processor_2.12</artifactId>
             <version>3.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaFactory.java
+++ b/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaFactory.java
@@ -1,0 +1,122 @@
+/*-
+ * ========================LICENSE_START=================================
+ * smooks-edg
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.edi.edg;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.smooks.edi.ect.DirectoryParser;
+import org.smooks.edi.ect.EdiParseException;
+import org.smooks.edi.ect.formats.unedifact.UnEdifactDefinitionReader;
+import org.smooks.edi.edg.template.InterchangeTemplate;
+import org.smooks.edi.edg.template.MessagesTemplate;
+import org.smooks.edi.edg.template.SegmentsTemplate;
+import org.smooks.edi.edisax.model.internal.Edimap;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.zip.ZipInputStream;
+
+public class EdifactDfdlSchemaFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EdifactDfdlSchemaFactory.class);
+    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+
+    public EdifactDfdlSchemaFile create(final String directoryPath, final String directoryParserImpl, final String outputDirectory) throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException, IOException, EdiParseException, XPathExpressionException, ParserConfigurationException, SAXException {
+        final InputStream resourceAsStream = EdifactDfdlSchemaGenerator.class.getResourceAsStream(directoryPath);
+        final Constructor<?> directoryParserClassConstructor = Class.forName(directoryParserImpl).getConstructor(ZipInputStream.class, boolean.class, boolean.class);
+        final DirectoryParser directoryParser = (DirectoryParser) directoryParserClassConstructor.newInstance(new ZipInputStream(resourceAsStream), true, true);
+
+        final Edimap edimap = UnEdifactDefinitionReader.parse(directoryParser);
+        final String[] namespace = edimap.getDescription().getNamespace().split(":");
+        final String version = namespace[3].replace("-", "").toUpperCase();
+        assertMessageReleaseNoEnum(version);
+        final String versionOutputDirectory = outputDirectory + "/" + version.toLowerCase();
+
+        final File segmentSchemaFile = new File(versionOutputDirectory + "/EDIFACT-Segments.dfdl.xsd");
+        EdifactDfdlSchemaFile edifactDfdlSchemaFile = new EdifactDfdlSchemaFile(versionOutputDirectory);
+        if (segmentSchemaFile.exists()) {
+            LOGGER.info("Skipping existing schema " + segmentSchemaFile.getAbsolutePath());
+        } else {
+            edifactDfdlSchemaFile.withSegmentsSchema(new SegmentsTemplate(version, edimap).materialise());
+        }
+
+        final MessagesTemplate messagesTemplate = new MessagesTemplate(version, directoryParser, edimap);
+        final File messageSchemaFile = new File(versionOutputDirectory + "/EDIFACT-Messages.dfdl.xsd");
+        if (messageSchemaFile.exists()) {
+            LOGGER.info("Skipping existing schema " + messageSchemaFile.getAbsolutePath());
+        } else {
+            edifactDfdlSchemaFile.withMessagesSchema(messagesTemplate.materialise());
+        }
+
+        final File interchangeSchemaFile = new File(versionOutputDirectory + "/EDIFACT-Interchange.dfdl.xsd");
+        if (interchangeSchemaFile.exists()) {
+            LOGGER.info("Skipping existing schema " + interchangeSchemaFile.getAbsolutePath());
+        } else {
+            edifactDfdlSchemaFile.withInterchangeSchema(new InterchangeTemplate(version, messagesTemplate.getMessageTypes()).materialise());
+        }
+
+        return edifactDfdlSchemaFile;
+    }
+
+    protected void assertMessageReleaseNoEnum(final String version) throws XPathExpressionException, IOException, SAXException, ParserConfigurationException {
+        final InputStream edifactServiceSegmentsDfdlSchema = EdifactDfdlSchemaGenerator.class.getResourceAsStream("/EDIFACT-Common/EDIFACT-Service-Segments-4.1.dfdl.xsd");
+        final XPathFactory xpathFactory = XPathFactory.newInstance();
+        final String messageReleaseNo = version.substring(1);
+        final XPathExpression xpathExp = xpathFactory.newXPath().compile(String.format("/schema/simpleType[@name=\"E0054-MessageReleaseNumber\"]/restriction/enumeration[@value=\"%s\"]", messageReleaseNo));
+        final Node enumeration = (Node) xpathExp.evaluate(DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().parse(edifactServiceSegmentsDfdlSchema), XPathConstants.NODE);
+        if (enumeration == null) {
+            throw new EdifactDfdlSchemaGeneratorException(String.format("Message release number for %s does not exist in EDIFACT-Service-Segments-4.1.dfdl.xsd", messageReleaseNo));
+        }
+    }
+}

--- a/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaFile.java
+++ b/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaFile.java
@@ -1,0 +1,152 @@
+/*-
+ * ========================LICENSE_START=================================
+ * smooks-edg
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.edi.edg;
+
+import org.apache.daffodil.japi.Daffodil;
+import org.apache.daffodil.japi.Diagnostic;
+import org.apache.daffodil.japi.ProcessorFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class EdifactDfdlSchemaFile {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EdifactDfdlSchemaFile.class);
+    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+    private static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+
+    private final String versionOutputDirectory;
+    private String segmentsSchema;
+    private String messagesSchema;
+    private String interchangeSchema;
+
+    public EdifactDfdlSchemaFile(String versionOutputDirectory) {
+        this.versionOutputDirectory = versionOutputDirectory;
+    }
+
+    public void withSegmentsSchema(String segmentsSchema) {
+        this.segmentsSchema = segmentsSchema;
+    }
+
+    public void withMessagesSchema(String messagesSchema) {
+        this.messagesSchema = messagesSchema;
+    }
+
+    public void withInterchangeSchema(String interchangeSchema) {
+        this.interchangeSchema = interchangeSchema;
+    }
+
+    public void write() throws XPathExpressionException, ParserConfigurationException, IOException, TransformerException, SAXException {
+        new File(versionOutputDirectory).mkdirs();
+
+        if (segmentsSchema != null) {
+            write(segmentsSchema, new File(versionOutputDirectory + "/EDIFACT-Segments.dfdl.xsd"));
+        }
+
+        if (messagesSchema != null) {
+            final File messageSchemaFile = new File(versionOutputDirectory + "/EDIFACT-Messages.dfdl.xsd");
+            write(messagesSchema, messageSchemaFile);
+            LOGGER.info("Validating schema {}...", messageSchemaFile.getPath());
+            compileSchema(messageSchemaFile);
+        }
+
+        if (interchangeSchema != null) {
+            write(interchangeSchema, new File(versionOutputDirectory + "/EDIFACT-Interchange.dfdl.xsd"));
+        }
+    }
+
+    protected void write(final String xml, final File file) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, TransformerException {
+        final DocumentBuilder documentBuilder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+        final Document document = documentBuilder.parse(new ByteArrayInputStream(xml.getBytes()));
+        stripWhitespaceTextNodes(document);
+
+        final Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xalan}indent-amount", "4");
+
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            transformer.transform(new DOMSource(document), new StreamResult(fileWriter));
+        }
+    }
+
+    protected void stripWhitespaceTextNodes(final Document document) throws XPathExpressionException {
+        final XPathFactory xpathFactory = XPathFactory.newInstance();
+        final XPathExpression xpathExp = xpathFactory.newXPath().compile("//text()[normalize-space(.) = '']");
+        final NodeList emptyTextNodes = (NodeList) xpathExp.evaluate(document, XPathConstants.NODESET);
+
+        for (int i = 0; i < emptyTextNodes.getLength(); i++) {
+            final Node emptyTextNode = emptyTextNodes.item(i);
+            emptyTextNode.getParentNode().removeChild(emptyTextNode);
+        }
+    }
+
+    protected void compileSchema(final File messageSchemaFile) throws IOException {
+        final ProcessorFactory processorFactory = Daffodil.compiler().compileFile(messageSchemaFile);
+        for (Diagnostic diagnostic : processorFactory.getDiagnostics()) {
+            if (diagnostic.isError()) {
+                throw new EdifactDfdlSchemaGeneratorException(diagnostic.getSomeCause());
+            }
+        }
+    }
+}

--- a/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaGeneratorException.java
+++ b/edg/src/main/java/org/smooks/edi/edg/EdifactDfdlSchemaGeneratorException.java
@@ -2,39 +2,39 @@
  * ========================LICENSE_START=================================
  * smooks-edg
  * %%
- * Copyright (C) 2020 Smooks
+ * Copyright (C) 2020 - 2024 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
- *
+ * 
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
- *
+ * 
  * ======================================================================
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * 
  * ======================================================================
- *
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -42,36 +42,24 @@
  */
 package org.smooks.edi.edg;
 
-import org.apache.daffodil.io.processors.charset.CharsetUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public class EdifactDfdlSchemaGeneratorException extends RuntimeException {
 
-import java.util.Arrays;
-
-public final class EdifactDfdlSchemaGenerator {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EdifactDfdlSchemaGenerator.class);
-
-    private EdifactDfdlSchemaGenerator() {
-
+    public EdifactDfdlSchemaGeneratorException() {
     }
 
-    public static void main(final String[] args) {
-        //FIXME: https://issues.apache.org/jira/browse/DAFFODIL-2827
-        CharsetUtils.supportedEncodingsString();
-        EdifactDfdlSchemaFactory edifactDfdlSchemaFactory = new EdifactDfdlSchemaFactory();
-        Arrays.stream(Arrays.copyOfRange(args, 0, args.length - 1)).parallel().forEach(a -> {
-            final String[] argAsArray = a.split(",");
-            final String directoryPath = argAsArray[0];
-            final String directoryParserImpl = argAsArray[1];
+    public EdifactDfdlSchemaGeneratorException(String message) {
+        super(message);
+    }
 
-            LOGGER.info("Generating schema from {}...", directoryPath);
-            try {
-                EdifactDfdlSchemaFile edifactDfdlSchemaFile = edifactDfdlSchemaFactory.create(directoryPath, directoryParserImpl, args[args.length - 1]);
-                edifactDfdlSchemaFile.write();
-            } catch (Exception e) {
-                throw new EdifactDfdlSchemaGeneratorException(e);
-            }
-        });
+    public EdifactDfdlSchemaGeneratorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EdifactDfdlSchemaGeneratorException(Throwable cause) {
+        super(cause);
+    }
+
+    public EdifactDfdlSchemaGeneratorException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/edg/src/main/java/org/smooks/edi/edg/template/MessagesTemplate.java
+++ b/edg/src/main/java/org/smooks/edi/edg/template/MessagesTemplate.java
@@ -43,14 +43,17 @@
 package org.smooks.edi.edg.template;
 
 import com.github.mustachejava.TemplateFunction;
-import org.apache.commons.jxpath.JXPathContext;
 import org.smooks.edi.ect.DirectoryParser;
 import org.smooks.edi.edisax.model.internal.Edimap;
 import org.smooks.edi.edisax.util.EDIUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MessagesTemplate extends Template {
@@ -68,7 +71,7 @@ public class MessagesTemplate extends Template {
         for (String messageType : messageTypes) {
             final Edimap messageTypeEdimap = directoryParser.getMappingModel(messageType, edimap);
             final Map<String, Object> messageDefinition = OBJECT_MAPPER.convertValue(messageTypeEdimap, OBJECT_MAPPER.getTypeFactory().constructMapType(Map.class, String.class, Object.class));
-            final List<Map<String, Object>> segments = (List<Map<String, Object>>) JXPathContext.newContext(messageDefinition).getValue("/segments/segments", List.class);
+            final List<Map<String, Object>> segments = (List<Map<String, Object>>) ((Map<String, Object>) messageDefinition.get("segments")).get("segments");
             templatizeSegments(segments);
 
             messageDefinitions.add(messageDefinition);

--- a/edg/src/test/java/org/smooks/edi/edg/EdifactDfdlSchemaFactoryTestCase.java
+++ b/edg/src/test/java/org/smooks/edi/edg/EdifactDfdlSchemaFactoryTestCase.java
@@ -2,39 +2,39 @@
  * ========================LICENSE_START=================================
  * smooks-edg
  * %%
- * Copyright (C) 2020 Smooks
+ * Copyright (C) 2020 - 2024 Smooks
  * %%
  * Licensed under the terms of the Apache License Version 2.0, or
  * the GNU Lesser General Public License version 3.0 or later.
- *
+ * 
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
- *
+ * 
  * ======================================================================
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ * 
  * ======================================================================
- *
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -42,36 +42,25 @@
  */
 package org.smooks.edi.edg;
 
-import org.apache.daffodil.io.processors.charset.CharsetUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
 
-import java.util.Arrays;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.IOException;
 
-public final class EdifactDfdlSchemaGenerator {
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EdifactDfdlSchemaGenerator.class);
+public class EdifactDfdlSchemaFactoryTestCase {
 
-    private EdifactDfdlSchemaGenerator() {
-
+    @Test
+    public void testAssertMessageReleaseNoEnumGivenUnknownMessageReleaseNo() {
+        assertThrows(RuntimeException.class, () -> new EdifactDfdlSchemaFactory().assertMessageReleaseNoEnum(RandomStringUtils.randomAlphanumeric(4)));
     }
 
-    public static void main(final String[] args) {
-        //FIXME: https://issues.apache.org/jira/browse/DAFFODIL-2827
-        CharsetUtils.supportedEncodingsString();
-        EdifactDfdlSchemaFactory edifactDfdlSchemaFactory = new EdifactDfdlSchemaFactory();
-        Arrays.stream(Arrays.copyOfRange(args, 0, args.length - 1)).parallel().forEach(a -> {
-            final String[] argAsArray = a.split(",");
-            final String directoryPath = argAsArray[0];
-            final String directoryParserImpl = argAsArray[1];
-
-            LOGGER.info("Generating schema from {}...", directoryPath);
-            try {
-                EdifactDfdlSchemaFile edifactDfdlSchemaFile = edifactDfdlSchemaFactory.create(directoryPath, directoryParserImpl, args[args.length - 1]);
-                edifactDfdlSchemaFile.write();
-            } catch (Exception e) {
-                throw new EdifactDfdlSchemaGeneratorException(e);
-            }
-        });
+    @Test
+    public void testAssertMessageReleaseNoEnumGivenKnownMessageReleaseNo() throws XPathExpressionException, IOException, ParserConfigurationException, SAXException {
+        new EdifactDfdlSchemaFactory().assertMessageReleaseNoEnum("D03B");
     }
 }


### PR DESCRIPTION
…ber type in EDIFACT-Service-Segments-4.1.dfdl.xsd

refactor: drop unmaintained commons-jxpath dependency from edg module

move away from static methods in EdifactDfdlSchemaFactory

Refs: #285