### PR TITLE
build: eliminate JavaDoc warnings

### DIFF
--- a/common-schemas/src/main/resources/EDIFACT-Common/IBM_EDI_Format.dfdl.xsd
+++ b/common-schemas/src/main/resources/EDIFACT-Common/IBM_EDI_Format.dfdl.xsd
@@ -115,7 +115,8 @@
                              nilKind="literalValue"
                              useNilForDefault="no"
                              floating="no"
-                             binaryNumberRep="binary">
+                             binaryNumberRep="binary"
+                             encodingErrorPolicy="replace">
                 </dfdl:format>
             </dfdl:defineFormat>
 

--- a/ect/src/main/java/org/smooks/edi/ect/DirectoryParser.java
+++ b/ect/src/main/java/org/smooks/edi/ect/DirectoryParser.java
@@ -88,7 +88,7 @@ public interface DirectoryParser {
 
     /**
      * Get the EDI Mapping Model for the named message.
-     * <p/>
+     * <br><br>
      * The Mapping Model is constructed after converting/translating the
      * message definition in the specification.  This is the "normalized"
      * definition of any EDI message in Smooks.  From the EDI Mapping Model,
@@ -110,7 +110,7 @@ public interface DirectoryParser {
 
     /**
      * Get the {@link EdiDirectory} instance for specification.
-     * <p/>
+     * <br><br>
      * Implementations should cache this instance.
      *
      * @param includeMessages Messages to include.

--- a/ect/src/main/java/org/smooks/edi/ect/EdiConvertionTool.java
+++ b/ect/src/main/java/org/smooks/edi/ect/EdiConvertionTool.java
@@ -66,7 +66,7 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * EDI Convertion Tool.
- * <p/>
+ * <br><br>
  * Takes the set of messages from an {@link DirectoryParser} and generates
  * a Smooks EDI Mapping Model archive that can be written to a zip file or folder.
  *
@@ -104,7 +104,7 @@ public class EdiConvertionTool {
      * @throws IOException Error writing Mapping Model configuration set.
      */
     public static Archive fromUnEdifactSpec(File specification, String urn) throws IOException {
-        return fromUnEdifactSpec(specification, urn, null);
+        return fromUnEdifactSpec(specification, urn, (String) null);
     }
 
     /**

--- a/edg/src/main/resources/EDIFACT-Templates/MessageSegment.xsd.mustache
+++ b/edg/src/main/resources/EDIFACT-Templates/MessageSegment.xsd.mustache
@@ -1,4 +1,4 @@
-<xsd:element  minOccurs="{{value.minOccurs}}" maxOccurs="{{value.maxOccurs}}" name="{{value.xmltag}}"
-              type="{{value.namespacePrefix}}:{{value.xmlName}}" dfdl:ref="ibmEdiFmt:EDISegmentFormat"
-              dfdl:initiator="{{value.xmltag}}"
-              {{#value.occursCountKind}}dfdl:occursCountKind="{{value.occursCountKind}}"{{/value.occursCountKind}}/>
+<xsd:element minOccurs="{{value.minOccurs}}" maxOccurs="{{value.maxOccurs}}" name="{{value.xmltag}}"
+             type="{{value.namespacePrefix}}:{{value.xmlName}}" dfdl:ref="ibmEdiFmt:EDISegmentFormat"
+             dfdl:initiator="{{value.xmltag}}"
+             {{#value.occursCountKind}}dfdl:occursCountKind="{{value.occursCountKind}}"{{/value.occursCountKind}}/>

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/BufferedSegmentListener.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/BufferedSegmentListener.java
@@ -44,7 +44,7 @@ package org.smooks.edi.edisax;
 
 /**
  * Buffered Segment listener.
- * <p/>
+ * <br><br>
  * Implementations of this interface can control when and how the {@link BufferedSegmentReader#moveToNextSegment()}
  * method returns true (segment exists) or false (segment does not exist).
  *

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/BufferedSegmentReader.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/BufferedSegmentReader.java
@@ -121,7 +121,7 @@ public class BufferedSegmentReader {
 
     /**
      * Change the encoding used to read the underlying EDI data stream.
-     * <p/>
+     * <br><br>
      * {@link #mark()} should have been called first.
      *
      * @param encoding The new encoding.
@@ -184,7 +184,7 @@ public class BufferedSegmentReader {
 
     /**
      * Restore the parent delimiters set.
-     * <p/>
+     * <br><br>
      * Be sure to {@link #getDelimitersStack() get the delimiters stack} and check
      * that it is not empty before popping.
      */
@@ -203,7 +203,7 @@ public class BufferedSegmentReader {
 
     /**
      * Set ignore new lines in the EDI Stream.
-     * <p/>
+     * <br><br>
      * Some EDI messages are formatted with new lines for readability and so the
      * new line characters should be ignored.
      *
@@ -233,7 +233,7 @@ public class BufferedSegmentReader {
 
     /**
      * Peek a fixed number of characters from the input source.
-     * <p/>
+     * <br><br>
      * Peek differs from {@link #read(int)} in that it leaves the
      * characters in the segment buffer.
      *
@@ -249,7 +249,7 @@ public class BufferedSegmentReader {
 
     /**
      * Peek a fixed number of characters from the input source.
-     * <p/>
+     * <br><br>
      * Peek differs from {@link #read(int)} in that it leaves the
      * characters in the segment buffer.
      *
@@ -307,7 +307,7 @@ public class BufferedSegmentReader {
 
     /**
      * Move to the next EDI segment.
-     * <p/>
+     * <br><br>
      * Simply reads and buffers the next EDI segment.  Clears the current contents of
      * the buffer before reading.
      *
@@ -320,7 +320,7 @@ public class BufferedSegmentReader {
 
     /**
      * Move to the next EDI segment.
-     * <p/>
+     * <br><br>
      * Simply reads and buffers the next EDI segment.
      *
      * @param clearBuffer Clear the segment buffer before reading.
@@ -467,7 +467,7 @@ public class BufferedSegmentReader {
 
     /**
      * Get the current segment "number".
-     * <p/>
+     * <br><br>
      * The first segment is "segment number 1".
      *
      * @return The "number" of the current segment.

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/EDIParser.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/EDIParser.java
@@ -63,7 +63,7 @@ import java.util.regex.Pattern;
 
 /**
  * EDI Parser.
- * <p/>
+ * <br><br>
  * Generates a stream of SAX events from an EDI message stream based on the supplied
  * {@link #setMappingModel(EdifactModel) mapping model}.
  *
@@ -86,7 +86,7 @@ import java.util.regex.Pattern;
  * the parser.  This model must be based on the
  * <a href="http://www.milyn.org/schema/edi-message-mapping-1.0.xsd">edi-message-mapping-1.0.xsd</a>
  * schema.
- * <p/>
+ * <br><br>
  * From this schema you can see that segment groups are supported (nested segments), including groups within groups,
  * repeating segments and repeating segment groups.  Be sure to review the
  * <a href="http://www.milyn.org/schema/edi-message-mapping-1.0.xsd">schema</a>.
@@ -95,9 +95,9 @@ import java.util.regex.Pattern;
  * The following illustration attempts to create a visualisation of the mapping process.  The "input-message.edi" file
  * specifies the EDI input, "edi-to-xml-order-mapping.xml" describes how to map that EDI message to SAX events and
  * "expected.xml" illustrates the XML that would result from applying the mapping.
- * <p/>
+ * <br><br>
  * <img src="doc-files/edi-mapping.png" />
- * <p/>
+ * <br><br>
  * So the above illustration attempts to highlight the following:
  * <ol>
  * 	<li>How the message delimiters (segment, field, component and sub-component) are specified in the mapping.  In particular, how special
@@ -130,7 +130,7 @@ import java.util.regex.Pattern;
  * <h3>Required Values</h3>
  * &lt;field&gt;, &lt;component&gt; and &lt;sub-component&gt; configurations support a "required" attribute, which
  * flags that &lt;field&gt;, &lt;component&gt; or &lt;sub-component&gt; as requiring a value.
- * <p/>
+ * <br><br>
  * By default, values are not required (fields, components and sub-components).
  *
  * <h3>Truncation</h3>
@@ -138,7 +138,7 @@ import java.util.regex.Pattern;
  * segment, this means that parser errors will not be generated when that segment does not specify trailing
  * fields that are not "required" (see "required" attribute above). Likewise for fields/components and
  * components/sub-components.
- * <p/>
+ * <br><br>
  * By default, segments, fields, and components are not truncatable.
  *
  * @author tfennelly
@@ -173,7 +173,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Parse the supplied mapping model config path and return the generated EdiMap.
-     * <p/>
+     * <br><br>
      * Can be used to set the mapping model to be used during the parsing operation.
      * See {@link #setMappingModel(EdifactModel)}.
      *
@@ -220,7 +220,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Parse the supplied mapping model config stream and return the generated EdiMap.
-     * <p/>
+     * <br><br>
      * Can be used to set the mapping model to be used during the parsing operation.
      * See {@link #setMappingModel(EdifactModel)}.
      *
@@ -238,7 +238,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Parse the supplied mapping model config stream and return the generated EdiMap.
-     * <p/>
+     * <br><br>
      * Can be used to set the mapping model to be used during the parsing operation.
      * See {@link #setMappingModel(EdifactModel)}.
      *
@@ -264,7 +264,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Parse the supplied mapping model config stream and return the generated EdiMap.
-     * <p/>
+     * <br><br>
      * Can be used to set the mapping model to be used during the parsing operation.
      * See {@link #setMappingModel(EdifactModel)}.
      *
@@ -282,7 +282,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Parse the supplied mapping model config stream and return the generated EdiMap.
-     * <p/>
+     * <br><br>
      * Can be used to set the mapping model to be used during the parsing operation.
      * See {@link #setMappingModel(EdifactModel)}.
      *
@@ -343,7 +343,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Set the EDI mapping model to be used in all subsequent parse operations.
-     * <p/>
+     * <br><br>
      * The model can be generated through a call to the {@link EDIParser}.
      *
      * @param mappingModel The mapping model.
@@ -453,7 +453,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Map a list of EDI Segments to SAX events.
-     * <p/>
+     * <br><br>
      * Reads the segments from the input stream and maps them based on the supplied list of expected segments.
      *
      * @param expectedSegments The list of expected segments.
@@ -466,7 +466,7 @@ public class EDIParser implements XMLReader {
 
     /**
      * Map a list of EDI Segments to SAX events.
-     * <p/>
+     * <br><br>
      * Reads the segments from the input stream and maps them based on the supplied list of expected segments.
      *
      * @param expectedSegments       The list of expected segments.

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/archive/Archive.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/archive/Archive.java
@@ -214,7 +214,7 @@ public class Archive {
 
     /**
      * Add an "empty" entry in the deployment.
-     * <p/>
+     * <br><br>
      * Equivalent to adding an empty folder.
      *
      * @param path The target path of the entry when added to the archive.
@@ -323,7 +323,7 @@ public class Archive {
 
     /**
      * Get the archive entries.
-     * <p/>
+     * <br><br>
      * The returned map entries are ordered in line with the order in which they were added
      * to the archive.
      *

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/interchange/EdiDirectory.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/interchange/EdiDirectory.java
@@ -49,7 +49,7 @@ import java.util.List;
 
 /**
  * EDI directory model.
- * <p/>
+ * <br><br>
  * Contains the mapping models for all message in an EDI directory/specification e.g.
  * for UN/EDIFACT it contains EDI mapping models for all the messages in a
  * UN/EDIFACT directory specification zip file.
@@ -84,7 +84,7 @@ public class EdiDirectory {
 
     /**
      * Get the message models.
-     * <p/>
+     * <br><br>
      * This list does not contain the {@link #getCommonModel() common} model.
      *
      * @return The message models.

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/model/EdifactModel.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/model/EdifactModel.java
@@ -197,7 +197,7 @@ public class EdifactModel {
 
     /**
      * Set a set of models that are associated with this model instance.
-     * <p/>
+     * <br><br>
      * An associate set of models could be (for example) the other models in
      * a UN/EDIFACT model set, or some other interchange type.
      *

--- a/edi-sax/src/main/java/org/smooks/edi/edisax/unedifact/UNEdifactInterchangeParser.java
+++ b/edi-sax/src/main/java/org/smooks/edi/edisax/unedifact/UNEdifactInterchangeParser.java
@@ -174,7 +174,7 @@ public class UNEdifactInterchangeParser implements XMLReader, NamespaceDeclarati
 
     /**
      * Set the EDI mapping model to be used in all subsequent parse operations.
-     * <p/>
+     * <br><br>
      * The model can be generated through a call to the {@link EDIParser}.
      *
      * @param registry The mapping model registry.

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
                 <configuration>
+                    <doclint>all,-missing</doclint>
                     <failOnError>false</failOnError>
                     <failOnWarnings>false</failOnWarnings>
                     <quiet>true</quiet>


### PR DESCRIPTION
refactor: add encodingErrorPolicy to EDI format to drop Daffodil warning